### PR TITLE
Fixes issues #7, #10, #13. Prefix matching related (java equivalent == LookingAt() )

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2542,7 +2542,7 @@ func maybeExtractCountryCode(
 func parsePrefixAsIdd(iddPattern *regexp.Regexp, number *builder.Builder) bool {
 	numStr := number.String()
 	ind := iddPattern.FindStringIndex(numStr)
-	if len(ind) == 0 {
+	if len(ind) == 0 || ind[0] != 0 {
 		return false
 	}
 	matchEnd := ind[1] // ind is a two element slice
@@ -2550,7 +2550,7 @@ func parsePrefixAsIdd(iddPattern *regexp.Regexp, number *builder.Builder) bool {
 	// a 0, since country calling codes cannot begin with 0.
 	find := CAPTURING_DIGIT_PATTERN.FindAllString(numStr[matchEnd:], -1)
 	if len(find) > 0 {
-		if NormalizeDigitsOnly(find[1]) == "0" {
+		if NormalizeDigitsOnly(find[0]) == "0" {
 			return false
 		}
 	}
@@ -2616,7 +2616,8 @@ func maybeStripNationalPrefixAndCarrierCode(
 		prefixMatcher = regexp.MustCompile(pat)
 		regexCache[pat] = prefixMatcher
 	}
-	if prefixMatcher.Match(number.Bytes()) {
+	isPrefixed := prefixMatcher.FindIndex(number.Bytes())
+	if len(isPrefixed) > 0 && isPrefixed[0] == 0 {
 		//if (prefixMatcher.lookingAt()) {
 		nationalNumberRule, ok :=
 			regexCache[metadata.GetGeneralDesc().GetNationalNumberPattern()]

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -609,11 +609,11 @@ func TestGetNationalSignificantNumber(t *testing.T) {
 }
 
 func Test_GetExampleNumberForType(t *testing.T) {
-	if reflect.DeepEqual(getTestNumber("DE_NUMBER"), GetExampleNumber("DE")) {
+	if !reflect.DeepEqual(getTestNumber("DE_NUMBER"), GetExampleNumber("DE")) {
 		t.Error("the example number for Germany should have been the " +
 			"same as the test number we're using")
 	}
-	if reflect.DeepEqual(
+	if !reflect.DeepEqual(
 		getTestNumber("DE_NUMBER"), GetExampleNumberForType("DE", FIXED_LINE)) {
 		t.Error("the example number for Germany should have been the " +
 			"same as the test number we're using [FIXED_LINE]")


### PR DESCRIPTION
In (at least) these 2 places, a regular match/FindIndex was used instead of enforcing matching from the start of the string, like LookingAt() does in the Java implementation.

So for maybeStripNationalPrefixAndCarrierCode, country prefixes (e.g. "0") were matched and truncated at any place in the number, and most cases were saved by the fact that the resulting number would be of an invalid size. But in some situations (like #13), the number legal size would be flexible enough to allow the incorrectly truncated number to go through.

Same thing for parsePrefixAsIdd. Furthermore, line 2553 find[1] was incorrect. You cannot make the assumption that len(find) > 1, so index 1 might be out of range. Java implem used groups(1) because groups(0) has a special meaning (== whole string), but it in fact used the first match, corresponding to find[0] here.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/14)
<!-- Reviewable:end -->
