### PR TITLE
Fix italianLeadingZeroes, added regression test

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2912,7 +2912,7 @@ func parseHelper(
 	if lengthOfNationalNumber > MAX_LENGTH_FOR_NSN {
 		return ErrNumTooLong
 	}
-	if !isLeadingZeroPossible(int(phoneNumber.GetCountryCode())) {
+	if isLeadingZeroPossible(int(phoneNumber.GetCountryCode())) {
 		setItalianLeadingZerosForPhoneNumber(
 			normalizedNationalNumber.String(), phoneNumber)
 	}

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -665,3 +665,43 @@ func Test_normalizeDiallableCharsOnly(t *testing.T) {
 		t.Error("did not correctly remove non-diallable characters")
 	}
 }
+
+func TestItalianLeadingZeroes(t *testing.T) {
+
+	tests := []struct {
+		num      string
+		region   string
+		expected string
+	}{
+		{
+			num:      "0491 570 156",
+			region:   "AU",
+			expected: "+61491570156",
+		},
+		{
+			num:      "02 5550 1234",
+			region:   "AU",
+			expected: "+61255501234",
+		},
+		{
+			num:      "+39.0399123456",
+			region:   "IT",
+			expected: "+390399123456",
+		},
+	}
+
+	for _, test := range tests {
+		n, err := Parse(test.num, test.region)
+		if err != nil {
+			t.Error("Failed to parse number %s", test.num)
+		}
+
+		if !IsValidNumberForRegion(n, test.region) {
+			t.Errorf("Number %v should be valid for region %s\n", n, test.region)
+		}
+		s := Format(n, E164)
+		if s != test.expected {
+			t.Errorf("Expected '%s', got '%s'", test.expected, s)
+		}
+	}
+}


### PR DESCRIPTION
The issue in #4 was not fixed, there was a small error in the condition in the PR that tackled it.
I added a unit test covering this issue.

Before:
    $ go test
    --- FAIL: TestItalianLeadingZeroes (0.00s)
            phonenumberutil_test.go:704: Expected '+61491570156', got '+610491570156'
            phonenumberutil_test.go:704: Expected '+61255501234', got '+610255501234'
            phonenumberutil_test.go:700: Number country_code:39 national_number:399123456  should be valid for region IT
            phonenumberutil_test.go:704: Expected '+390399123456', got '+39399123456'
    FAIL
    exit status 1
    FAIL    _/tmp/libphonenumber    0.023s

After:
    $ go test
    PASS
    ok      _/tmp/libphonenumber    0.017s

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/15)
<!-- Reviewable:end -->
