### PR TITLE
Fix #17 -- Stricter match in isNumberMatchingDesc

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2044,19 +2044,19 @@ func getMetadataForNonGeographicalRegion(countryCallingCode int) *PhoneMetadata 
 func isNumberPossibleForDesc(
 	nationalNumber string, numberDesc *PhoneNumberDesc) bool {
 
-	pat, ok := regexCache[numberDesc.GetPossibleNumberPattern()]
+	possiblePattern := "^(?:" + numberDesc.GetPossibleNumberPattern() + ")$" // Strictly match
+	pat, ok := regexCache[possiblePattern]
 	if !ok {
-		patP := numberDesc.GetPossibleNumberPattern()
-		pat = regexp.MustCompile(patP)
-		regexCache[patP] = pat
+		pat = regexp.MustCompile(possiblePattern)
+		regexCache[possiblePattern] = pat
 	}
 	return pat.MatchString(nationalNumber)
 }
 
 func isNumberMatchingDesc(nationalNumber string, numberDesc *PhoneNumberDesc) bool {
-	pat, ok := regexCache[numberDesc.GetNationalNumberPattern()]
+	patP := "^(?:" + numberDesc.GetNationalNumberPattern() + ")$" // Strictly match
+	pat, ok := regexCache[patP]
 	if !ok {
-		patP := numberDesc.GetNationalNumberPattern()
 		pat = regexp.MustCompile(patP)
 		regexCache[patP] = pat
 	}

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -205,6 +205,11 @@ func Test_IsValidNumber(t *testing.T) {
 			err:     nil,
 			isValid: true,
 			region:  "US",
+		}, {
+			input:   "+343511234567",
+			err:     nil,
+			isValid: false,
+			region:  "ES",
 		},
 	}
 


### PR DESCRIPTION
Some invalid numbers (e.g. too long) would pass as valid because the regexp match was not strict enough, ie a 10 or 11 long number would still match \d{9}, since the regexp match would occur on a substring of it.
Added ^$ (with (?:) to work with OR'ed alternatives) to enforce the match on the whole string.

Added a regression test in Test_IsValid()

This fixes #17 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/18)
<!-- Reviewable:end -->
