### PR TITLE
When checking leading digits, match the beginning of the string

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2137,7 +2137,7 @@ func getRegionCodeForNumberFromRegionList(
 		if len(metadata.GetLeadingDigits()) > 0 {
 			pat, ok := regexCache[metadata.GetLeadingDigits()]
 			if !ok {
-				patP := metadata.GetLeadingDigits()
+				patP := "^" + metadata.GetLeadingDigits()
 				pat = regexp.MustCompile(patP)
 				regexCache[patP] = pat
 			}

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -210,6 +210,11 @@ func Test_IsValidNumber(t *testing.T) {
 			err:     nil,
 			isValid: false,
 			region:  "ES",
+		}, {
+			input:   "+12424654321",
+			err:     nil,
+			isValid: true,
+			region:  "BS",
 		},
 	}
 


### PR DESCRIPTION
regexp.MatchString looks for a match anywhere; so we have to explicitly bind the regular expression to the beginning of the string with a caret (^).

As an example, without this, the number +124246... incorrectly matches 246 (Barbados) instead of 242 (Bahamas). This affects all numbers that contain leadingDigits from a region with the same country code but earlier in the CountryCodeToRegion slice (e.g. in the previous example "BB" comes before "BS"). US numbers are unaffected since "US" is first in the slice for country code 1.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/22)
<!-- Reviewable:end -->
