### PR TITLE
Fix many instances of loose regex matches.

### DIFF
--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -321,14 +321,14 @@ func TestFormat(t *testing.T) {
 		frmt   PhoneNumberFormat
 	}{
 		{
-			in:     "01932 869755",
+			in:     "019 3286 9755",
 			region: "GB",
-			exp:    "019 3286 9755",
+			exp:    "01932 869755",
 			frmt:   NATIONAL,
 		}, {
 			in:     "+44 (0) 1932 869755",
 			region: "GB",
-			exp:    "+44 19 3286 9755",
+			exp:    "+44 1932 869755",
 			frmt:   INTERNATIONAL,
 		}, {
 			in:     "4431234567",


### PR DESCRIPTION
I reviewed most of the matching logic following #22, and found remaining instances of matches that were not strict enough.

I patched the change in #22 too which was partially incorrect (need grouping parentheses otherwise OR'ed patterns will ignore the ^). Also, the regex cache lookup used the pattern without the ^, but saved it with the ^, causing the lookup to always fail.

Most of the fixes follow the same logic.
This highlighted issues in testNumberLengthAgainstPattern(): numbers too long could be accepted.
I rewrote the logic to use FindStringIndex indexes instead, to distinguish between exact match (is possible) / partial start match (too long) / no match (too short), like the Java implementation does.

Also detected issues in chooseFormattingPatternForNumber() which, because of unbounded matches would pick the wrong formatting. This is fixed, and changes the behaviour of e.g. the GB numbers in the TestFormat unit tests. This got me alarmed a bit, because the correct implementation following the java implem produced errors in the unit tests. As it turns out, the unit tests were erroneous and expected an incorrect value (see https://libphonenumber.appspot.com/ with number +441932869755). This patch produces the expected results. As such, I corrected the unit test to expect the correct values.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/23)
<!-- Reviewable:end -->
