### PR TITLE
Create potentialNationalNumber from the copy of normalizedNationalNumber

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2952,9 +2952,10 @@ func parseHelper(
 	if len(normalizedNationalNumber.String()) < MIN_LENGTH_FOR_NSN {
 		return ErrTooShortNSN
 	}
+
 	if regionMetadata != nil {
 		carrierCode := builder.NewBuilder(nil)
-		potentialNationalNumber := builder.NewBuilder(normalizedNationalNumber.Bytes())
+		potentialNationalNumber := builder.NewBuilder([]byte(normalizedNationalNumber.String()))
 		maybeStripNationalPrefixAndCarrierCode(
 			potentialNationalNumber, regionMetadata, carrierCode)
 		// We require that the NSN remaining after stripping the national

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2955,7 +2955,9 @@ func parseHelper(
 
 	if regionMetadata != nil {
 		carrierCode := builder.NewBuilder(nil)
-		potentialNationalNumber := builder.NewBuilder([]byte(normalizedNationalNumber.String()))
+		bufferCopy := make([]byte, normalizedNationalNumber.Len())
+		copy(bufferCopy, normalizedNationalNumber.Bytes())
+		potentialNationalNumber := builder.NewBuilder(bufferCopy)
 		maybeStripNationalPrefixAndCarrierCode(
 			potentialNationalNumber, regionMetadata, carrierCode)
 		// We require that the NSN remaining after stripping the national

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -50,6 +50,11 @@ func TestParse(t *testing.T) {
 			err:         nil,
 			expectedNum: 951178619,
 			region:      "US",
+		}, {
+			input:       "+33 07856952",
+			err:         nil,
+			expectedNum: 7856952,
+			region:      "",
 		},
 	}
 


### PR DESCRIPTION
The function `maybeStripNationalPrefixAndCarrierCode` will modify the underlying data of its first argument (the national number).
With the current implementation, the value of `normalizedNationalNumber` could be altered unintentionally by this function, as
`potentialNationalNumber` and `normalizedNationalNumber` are sharing the same underlying byte slice. To solve the problem, we can
create `potentialNationalNumber` from a copy of `normalizedNationalNumber`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/37)

<!-- Reviewable:end -->
