### PR TITLE
Fix leading zero

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2952,9 +2952,10 @@ func parseHelper(
 	if len(normalizedNationalNumber.String()) < MIN_LENGTH_FOR_NSN {
 		return ErrTooShortNSN
 	}
+
 	if regionMetadata != nil {
 		carrierCode := builder.NewBuilder(nil)
-		potentialNationalNumber := builder.NewBuilder(normalizedNationalNumber.Bytes())
+		potentialNationalNumber := builder.NewBuilder([]byte(normalizedNationalNumber.String()))
 		maybeStripNationalPrefixAndCarrierCode(
 			potentialNationalNumber, regionMetadata, carrierCode)
 		// We require that the NSN remaining after stripping the national

--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -2978,10 +2978,8 @@ func parseHelper(
 	if lengthOfNationalNumber > MAX_LENGTH_FOR_NSN {
 		return ErrNumTooLong
 	}
-	if isLeadingZeroPossible(int(phoneNumber.GetCountryCode())) {
-		setItalianLeadingZerosForPhoneNumber(
-			normalizedNationalNumber.String(), phoneNumber)
-	}
+	setItalianLeadingZerosForPhoneNumber(
+		normalizedNationalNumber.String(), phoneNumber)
 	val, _ := strconv.ParseUint(normalizedNationalNumber.String(), 10, 64)
 	phoneNumber.NationalNumber = proto.Uint64(val)
 	return nil

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -50,6 +50,11 @@ func TestParse(t *testing.T) {
 			err:         nil,
 			expectedNum: 951178619,
 			region:      "US",
+		}, {
+			input:       "+33 07856952",
+			err:         nil,
+			expectedNum: 7856952,
+			region:      "",
 		},
 	}
 

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -362,6 +362,12 @@ func TestFormat(t *testing.T) {
 			exp:    "tel:+1-443-123-4567",
 			frmt:   RFC3966,
 		},
+		{
+			in:     "+1 100-083-0033",
+			region: "US",
+			exp:    "+1 000830033",
+			frmt:   INTERNATIONAL,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
The phone number `+1 100-083-0033` should be parsed and formatted as `+1 000830033`. But the current implement returns `+1 830033` instead. This is because we can `isLeadingZeroPossible` before `setItalianLeadingZerosForPhoneNumber` in `parseHelper`. 

After checking the original implementation of the [library](https://github.com/googlei18n/libphonenumber/blob/master/cpp/src/phonenumbers/phonenumberutil.cc), it seems that the `isLeadingZeroPossible` check is unnecessary.  See [here](https://github.com/googlei18n/libphonenumber/blob/master/cpp/src/phonenumbers/phonenumberutil.cc#L2010) (C++) and [here](https://github.com/googlei18n/libphonenumber/blob/master/java/libphonenumber/src/com/google/i18n/phonenumbers/PhoneNumberUtil.java#L3053) (Java)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/38)

<!-- Reviewable:end -->
