### PR TITLE
Fix errors reported by go vet

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -3211,10 +3211,6 @@ func isNumberMatchWithOneNumber(
 		}
 		return isNumberMatchWithNumbers(firstNumber, secondNumberProto)
 	}
-
-	// One or more of the phone numbers we are trying to match is not
-	// a viable phone number.
-	return NOT_A_NUMBER
 }
 
 // Returns true if the number can be dialled from outside the region, or

--- a/phonenumberutil_test.go
+++ b/phonenumberutil_test.go
@@ -735,7 +735,7 @@ func runTestBatch(t *testing.T, tests []testCase) {
 	for _, test := range tests {
 		n, err := Parse(test.num, test.region)
 		if err != nil {
-			t.Errorf("Failed to parse number %s: %s", err)
+			t.Errorf("Failed to parse number %s: %s", test.num, err)
 		}
 
 		if IsValidNumberForRegion(n, test.region) != test.valid {


### PR DESCRIPTION
A block of code in phonenumberutil is unreachable, and a test does not have the
correct number of arguments for a format string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/41)
<!-- Reviewable:end -->
