### PR TITLE
Bugfix: Encoding of country code in FormatOutOfCountryCallingNumber

### DIFF
--- a/phonenumberutil.go
+++ b/phonenumberutil.go
@@ -1412,14 +1412,7 @@ func FormatOutOfCountryCallingNumber(
 	if len(internationalPrefixForFormatting) > 0 {
 		formattedBytes := formattedNumber.Bytes()
 		formattedBytes = append([]byte(" "), formattedBytes...)
-		// we know countryCallingCode is really an int32
-		intBuf := []byte{
-			byte(countryCallingCode >> 24),
-			byte(countryCallingCode >> 16),
-			byte(countryCallingCode >> 8),
-			byte(countryCallingCode),
-		}
-		formattedBytes = append(intBuf, formattedBytes...)
+		formattedBytes = append([]byte(strconv.Itoa(countryCallingCode)), formattedBytes...)
 		formattedBytes = append([]byte(" "), formattedBytes...)
 		formattedBytes = append(
 			[]byte(internationalPrefixForFormatting), formattedBytes...)


### PR DESCRIPTION
Minimal testcase:

```
phonenumber, err := libphonenumber.Parse("+3587884512974", "DE")
fmt.Println(libphonenumber.FormatOutOfCountryCallingNumber(phonenumber,
"DE"))
```