### PR TITLE
Added Kosovo to CountryCodeToRegion map

### DIFF
--- a/countrycodetoregionmap.go
+++ b/countrycodetoregionmap.go
@@ -135,6 +135,7 @@ var CountryCodeToRegion = map[int][]string{
 	380: []string{"UA"},
 	381: []string{"RS"},
 	382: []string{"ME"},
+	383: []string{"XK"},
 	385: []string{"HR"},
 	386: []string{"SI"},
 	387: []string{"BA"},


### PR DESCRIPTION
Kosovo is missing from the CountryCodeToRegion map.

Country code is [383](https://en.wikipedia.org/wiki/Telephone_numbers_in_Kosovo) and region code is [XK](https://geonames.wordpress.com/2010/03/08/xk-country-code-for-kosovo/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ttacon/libphonenumber/69)
<!-- Reviewable:end -->
